### PR TITLE
Set author name and slightly shorten title

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,12 +1,12 @@
 Uuid: 2da0e069b2944fcab691f6d00b165078
 ExtensionType: 1
-Name: BeanStack - Stack-trace Fingerprinter
+Name: BeanStack, Stacktrace Fingerprinter
 RepoName: beanstack-stacktrace-fingerprinter
 ScreenVersion: 0.7.0
 SerialVersion: 6
 MinPlatformVersion: 2
 ProOnly: True
-Author: BeanStack
+Author: X41 D-Sec GmbH
 ShortDescription: Java Fingerprinting using Stack Traces.
 EntryPoint: beanstack.jar
 BuildCommand: ./gradlew build


### PR DESCRIPTION
Hi! We just noticed that the author field was not set to the company name, and most of the title is not visible in the default column width in Burp Suite so I tried to squeeze in a few more chars there.

Thank you :)